### PR TITLE
fix deprecation warning for keyword args in a hash

### DIFF
--- a/lib/r509/middleware/certwriter.rb
+++ b/lib/r509/middleware/certwriter.rb
@@ -32,7 +32,7 @@ module R509
                         filename = File.join(file_path,
                             "#{cert.subject.CN}_#{params["ca"]}_#{cert.hexserial}.pem").
                             gsub("*", "STAR").
-                            encode(Encoding.find("ASCII"), {:invalid => :replace, :undef => :replace, :replace => "", :universal_newline => true})
+                            encode(Encoding.find("ASCII"), :invalid => :replace, :undef => :replace, :replace => "", :universal_newline => true)
                         log.info "Writing: #{filename}"
                         File.open(filename, "w"){|f| f.write(cert.to_s)}
                     rescue => e


### PR DESCRIPTION
Hi,

I recently noticed a depracation warning when running with ruby2.7
This is a fix for it (will be required to run with ruby >=3)

Thanks for your work,
Valentin